### PR TITLE
Recommendation algorithm finetuning

### DIFF
--- a/backend/routes/scoring-helper-functions.js
+++ b/backend/routes/scoring-helper-functions.js
@@ -174,11 +174,19 @@ const computeProductScore = (product, lovedProducts, dislikedProducts, userSkinT
 
     // ========== combine all scores ===========
     let weights = {}; // can adjust weights further
-    weights['productSkinTypeScore'] = 5;
-    weights['ingredientSkinTypeScore'] = 1;
-    weights['productConcernsScore'] = 2.5;
-    weights['ingredientConcernsScore'] = 0.5;
-    weights['popularityScore'] = 1;
+    if(product.ingredients.length > 0) {
+        weights['productSkinTypeScore'] = 5;
+        weights['ingredientSkinTypeScore'] = 1;
+        weights['productConcernsScore'] = 2.5;
+        weights['ingredientConcernsScore'] = 0.5;
+        weights['popularityScore'] = 1;
+    } else {
+        weights['productSkinTypeScore'] = 5.5;
+        weights['ingredientSkinTypeScore'] = 0;
+        weights['productConcernsScore'] = 3;
+        weights['ingredientConcernsScore'] = 0;
+        weights['popularityScore'] = 1.5;
+    }
 
     let totalScore = 0;
     totalScore += productSkinTypeScore * weights['productSkinTypeScore'];

--- a/backend/routes/scoring-helper-functions.js
+++ b/backend/routes/scoring-helper-functions.js
@@ -131,7 +131,6 @@ const computeProductScore = (product, lovedProducts, dislikedProducts, userSkinT
     }
 
     for(const ingredientId of lovedIngredients) {
-        console.log(ingredientId);
         if(product.ingredients.some(i => i.id === ingredientId)) {
             lovedProductOverlapScore += 0.5; // extra boost for loved ingredient
         }

--- a/backend/routes/test.js
+++ b/backend/routes/test.js
@@ -1582,6 +1582,81 @@ const user3 = { // tons of liked and disliked products to test parsing liked/dis
 	]
 }
 
+const user4 = {
+	"username": "victoria2",
+	"concerns": [
+		"redness & irritation",
+		"acne & blemishes"
+	],
+	"skin_type": [
+		"oily",
+		"combination"
+	],
+	"loved_products": [],
+	"saved_products": [],
+	"disliked_products": [
+		{
+			"id": 27,
+			"brand": "The Inkey List",
+			"name": "Niacinamide Oil Control Serum",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "serum",
+			"price": "7",
+			"concerns": [
+				"acne & blemishes",
+				"redness & irritation"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 342,
+					"name": "squalane",
+					"ingredient_type": "moisturizing, skin softening",
+					"purpose": "deeply moisturizes and softens skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 6
+		}
+	]
+}
+
 const product1 =  {
 	"id": 20,
 	"brand": "The Ordinary",

--- a/backend/routes/test.js
+++ b/backend/routes/test.js
@@ -1,6 +1,6 @@
 const {computeProductScore} = require('./scoring-helper-functions.js');
 
-const userInfo = {
+const user1 = { // generic user
 	"username": "victoria1",
 	"concerns": [
 		"fine lines & wrinkles",
@@ -307,7 +307,1282 @@ const userInfo = {
 	]
 }
 
-const sampleProduct =  {
+const user2 = { // lots of loved products
+	"username": "victoria",
+	"concerns": [
+		"texture"
+	],
+	"skin_type": [
+		"dry",
+		"normal"
+	],
+	"loved_products": [
+		{
+			"id": 12,
+			"brand": "The Ordinary",
+			"name": "Alpha Arbutin 2% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031441-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "10",
+			"concerns": [
+				"hyperpigmentation (dark spots)",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 5
+		},
+		{
+			"id": 31,
+			"brand": "The Ordinary",
+			"name": "Lactic Acid 10% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031433-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "8",
+			"concerns": [
+				"texture",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 107,
+					"name": "lactic acid",
+					"ingredient_type": "exfoliant, ph adjuster",
+					"purpose": "exfoliates and maintains ph balance",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"texture",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 8.6
+		},
+		{
+			"id": 53,
+			"brand": "The Ordinary",
+			"name": "Salicylic Acid 2% Solution",
+			"image": "https://www.sephora.com/productimages/sku/s2611390-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "7",
+			"concerns": [
+				"acne & blemishes",
+				"texture"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 257,
+					"name": "salicylic acid",
+					"ingredient_type": "bha, exfoliant, acne treatment",
+					"purpose": "deep exfoliant, helps with acne treatment and clogged pores",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"acne & blemishes"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 5.2
+		},
+		{
+			"id": 9,
+			"brand": "The Ordinary",
+			"name": "Niacinamide 10% + Zinc 1%  Serum for Oily Skin",
+			"image": "https://www.sephora.com/productimages/sku/s2031391-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "6",
+			"concerns": [
+				"acne & blemishes"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 2537,
+					"name": "zinc pca",
+					"ingredient_type": "zinc compound",
+					"purpose": "controls oil production, anti-inflammatory, regulates sebum",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"redness & irritation"
+					]
+				}
+			],
+			"score": 8.5
+		},
+		{
+			"id": 3,
+			"brand": "Kiehl's",
+			"name": "Powerful-Strength Line-Reducing Concentrate",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "serum",
+			"price": "70",
+			"concerns": [
+				"fine lines & wrinkles",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 26,
+			"brand": "Glow Recipe",
+			"name": "Mini Watermelon Glow PHA + BHA Pore-Tight Toner",
+			"image": "https://www.sephora.com/productimages/sku/s2421519-main-zoom.jpg?imwidth=270&pb=clean-planet-aware",
+			"product_type": "toner",
+			"price": "16",
+			"concerns": [
+				"texture",
+				"dullness",
+				"dryness"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 10
+		}
+	],
+	"saved_products": [
+		{
+			"id": 6,
+			"brand": "Olay",
+			"name": "Regenerist Retinol 24 Night Moisturizer",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "retinol",
+			"price": "38",
+			"concerns": [
+				"fine lines & wrinkles",
+				"texture"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 2171,
+					"name": "retinol",
+					"ingredient_type": "vitamin a",
+					"purpose": "anti-aging, reduces wrinkles",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"fine lines & wrinkles"
+					]
+				}
+			],
+			"score": 5.6
+		},
+		{
+			"id": 1,
+			"brand": "EltaMD",
+			"name": "UV Clear Broad-Spectrum SPF 46",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "sunscreen",
+			"price": "39",
+			"concerns": [
+				"acne & blemishes",
+				"redness & irritation"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 774,
+					"name": "zinc oxide",
+					"ingredient_type": "mineral",
+					"purpose": "sunscreen, soothing, anti-inflammatory",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"hyperpigmentation (dark spots)",
+						"redness & irritation"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 0
+		}
+	],
+	"disliked_products": [
+		{
+			"id": 3,
+			"brand": "Kiehl's",
+			"name": "Powerful-Strength Line-Reducing Concentrate",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "serum",
+			"price": "70",
+			"concerns": [
+				"fine lines & wrinkles",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 1,
+			"brand": "EltaMD",
+			"name": "UV Clear Broad-Spectrum SPF 46",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "sunscreen",
+			"price": "39",
+			"concerns": [
+				"acne & blemishes",
+				"redness & irritation"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 774,
+					"name": "zinc oxide",
+					"ingredient_type": "mineral",
+					"purpose": "sunscreen, soothing, anti-inflammatory",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"hyperpigmentation (dark spots)",
+						"redness & irritation"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 0
+		}
+	]
+}
+
+const user3 = { // tons of liked and disliked products to test parsing liked/disliked
+	"username": "victoria",
+	"concerns": [
+		"texture"
+	],
+	"skin_type": [
+		"dry",
+		"normal"
+	],
+	"loved_products": [
+		{
+			"id": 12,
+			"brand": "The Ordinary",
+			"name": "Alpha Arbutin 2% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031441-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "10",
+			"concerns": [
+				"hyperpigmentation (dark spots)",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3.3
+		},
+		{
+			"id": 31,
+			"brand": "The Ordinary",
+			"name": "Lactic Acid 10% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031433-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "8",
+			"concerns": [
+				"texture",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 107,
+					"name": "lactic acid",
+					"ingredient_type": "exfoliant, ph adjuster",
+					"purpose": "exfoliates and maintains ph balance",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"texture",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 6.6
+		},
+		{
+			"id": 53,
+			"brand": "The Ordinary",
+			"name": "Salicylic Acid 2% Solution",
+			"image": "https://www.sephora.com/productimages/sku/s2611390-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "7",
+			"concerns": [
+				"acne & blemishes",
+				"texture"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 257,
+					"name": "salicylic acid",
+					"ingredient_type": "bha, exfoliant, acne treatment",
+					"purpose": "deep exfoliant, helps with acne treatment and clogged pores",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"acne & blemishes"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 9,
+			"brand": "The Ordinary",
+			"name": "Niacinamide 10% + Zinc 1%  Serum for Oily Skin",
+			"image": "https://www.sephora.com/productimages/sku/s2031391-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "6",
+			"concerns": [
+				"acne & blemishes"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 2537,
+					"name": "zinc pca",
+					"ingredient_type": "zinc compound",
+					"purpose": "controls oil production, anti-inflammatory, regulates sebum",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"redness & irritation"
+					]
+				}
+			],
+			"score": 6.3
+		},
+		{
+			"id": 3,
+			"brand": "Kiehl's",
+			"name": "Powerful-Strength Line-Reducing Concentrate",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "serum",
+			"price": "70",
+			"concerns": [
+				"fine lines & wrinkles",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 26,
+			"brand": "Glow Recipe",
+			"name": "Mini Watermelon Glow PHA + BHA Pore-Tight Toner",
+			"image": "https://www.sephora.com/productimages/sku/s2421519-main-zoom.jpg?imwidth=270&pb=clean-planet-aware",
+			"product_type": "toner",
+			"price": "16",
+			"concerns": [
+				"texture",
+				"dullness",
+				"dryness"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 8.5
+		}
+	],
+	"saved_products": [
+		{
+			"id": 6,
+			"brand": "Olay",
+			"name": "Regenerist Retinol 24 Night Moisturizer",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "retinol",
+			"price": "38",
+			"concerns": [
+				"fine lines & wrinkles",
+				"texture"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 2171,
+					"name": "retinol",
+					"ingredient_type": "vitamin a",
+					"purpose": "anti-aging, reduces wrinkles",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"fine lines & wrinkles"
+					]
+				}
+			],
+			"score": 5.7
+		},
+		{
+			"id": 1,
+			"brand": "EltaMD",
+			"name": "UV Clear Broad-Spectrum SPF 46",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "sunscreen",
+			"price": "39",
+			"concerns": [
+				"acne & blemishes",
+				"redness & irritation"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 774,
+					"name": "zinc oxide",
+					"ingredient_type": "mineral",
+					"purpose": "sunscreen, soothing, anti-inflammatory",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"hyperpigmentation (dark spots)",
+						"redness & irritation"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 0
+		}
+	],
+	"disliked_products": [
+		{
+			"id": 12,
+			"brand": "The Ordinary",
+			"name": "Alpha Arbutin 2% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031441-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "10",
+			"concerns": [
+				"hyperpigmentation (dark spots)",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3.3
+		},
+		{
+			"id": 31,
+			"brand": "The Ordinary",
+			"name": "Lactic Acid 10% + HA",
+			"image": "https://www.sephora.com/productimages/sku/s2031433-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "8",
+			"concerns": [
+				"texture",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 107,
+					"name": "lactic acid",
+					"ingredient_type": "exfoliant, ph adjuster",
+					"purpose": "exfoliates and maintains ph balance",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"texture",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 6.6
+		},
+		{
+			"id": 53,
+			"brand": "The Ordinary",
+			"name": "Salicylic Acid 2% Solution",
+			"image": "https://www.sephora.com/productimages/sku/s2611390-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "7",
+			"concerns": [
+				"acne & blemishes",
+				"texture"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 257,
+					"name": "salicylic acid",
+					"ingredient_type": "bha, exfoliant, acne treatment",
+					"purpose": "deep exfoliant, helps with acne treatment and clogged pores",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"acne & blemishes"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 9,
+			"brand": "The Ordinary",
+			"name": "Niacinamide 10% + Zinc 1%  Serum for Oily Skin",
+			"image": "https://www.sephora.com/productimages/sku/s2031391-main-zoom.jpg?imwidth=270",
+			"product_type": "serum",
+			"price": "6",
+			"concerns": [
+				"acne & blemishes"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 2537,
+					"name": "zinc pca",
+					"ingredient_type": "zinc compound",
+					"purpose": "controls oil production, anti-inflammatory, regulates sebum",
+					"skin_type": [
+						"oily"
+					],
+					"concerns": [
+						"redness & irritation"
+					]
+				}
+			],
+			"score": 6.3
+		},
+		{
+			"id": 3,
+			"brand": "Kiehl's",
+			"name": "Powerful-Strength Line-Reducing Concentrate",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "serum",
+			"price": "70",
+			"concerns": [
+				"fine lines & wrinkles",
+				"dullness"
+			],
+			"skin_type": [
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				},
+				{
+					"id": 1604,
+					"name": "glycerin",
+					"ingredient_type": "humectant",
+					"purpose": "retains moisture, hydrates skin",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 3
+		},
+		{
+			"id": 1,
+			"brand": "EltaMD",
+			"name": "UV Clear Broad-Spectrum SPF 46",
+			"image": "https://placeholderimagegenerator.com/wp-content/uploads/2024/12/Light-placeholder-image-portrait_jpg_.jpg",
+			"product_type": "sunscreen",
+			"price": "39",
+			"concerns": [
+				"acne & blemishes",
+				"redness & irritation"
+			],
+			"skin_type": [
+				"oily",
+				"combination"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 774,
+					"name": "zinc oxide",
+					"ingredient_type": "mineral",
+					"purpose": "sunscreen, soothing, anti-inflammatory",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"hyperpigmentation (dark spots)",
+						"redness & irritation"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 0
+		},
+		{
+			"id": 26,
+			"brand": "Glow Recipe",
+			"name": "Mini Watermelon Glow PHA + BHA Pore-Tight Toner",
+			"image": "https://www.sephora.com/productimages/sku/s2421519-main-zoom.jpg?imwidth=270&pb=clean-planet-aware",
+			"product_type": "toner",
+			"price": "16",
+			"concerns": [
+				"texture",
+				"dullness",
+				"dryness"
+			],
+			"skin_type": [
+				"dry",
+				"oily",
+				"combination",
+				"normal"
+			],
+			"ingredients": [
+				{
+					"id": 504,
+					"name": "niacinamide",
+					"ingredient_type": "active ingredient",
+					"purpose": "anti-inflammatory, brightening",
+					"skin_type": [
+						"dry",
+						"oily",
+						"combination",
+						"normal"
+					],
+					"concerns": [
+						"redness & irritation",
+						"dullness"
+					]
+				},
+				{
+					"id": 957,
+					"name": "hyaluronic acid",
+					"ingredient_type": "humectant",
+					"purpose": "moisturizing, skin plumping",
+					"skin_type": [
+						"dry"
+					],
+					"concerns": [
+						"dryness"
+					]
+				}
+			],
+			"score": 8.5
+		}
+	]
+}
+
+const product1 =  {
 	"id": 20,
 	"brand": "The Ordinary",
 	"name": "Glycolic Acid 7% Exfoliating and Brightening Daily Toner",
@@ -341,9 +1616,45 @@ const sampleProduct =  {
 	"disliked_by_user": []
 }
 
-const testComputeScore = async () => {
+const product2 = {
+	"id": 29,
+	"brand": "fresh",
+	"name": "Kombucha Antioxidant Facial Treatment Essence",
+	"image": "https://www.sephora.com/productimages/sku/s2658979-main-zoom.jpg?imwidth=270&pb=clean-at-sephora",
+	"product_type": "toner",
+	"price": "85",
+	"concerns": [
+		"texture",
+		"dullness",
+		"dryness"
+	],
+	"skin_type": [
+		"dry",
+		"oily",
+		"combination",
+		"normal"
+	],
+	"ingredients": [
+		{
+			"id": 957,
+			"name": "hyaluronic acid",
+			"ingredient_type": "humectant",
+			"purpose": "moisturizing, skin plumping",
+			"skin_type": [
+				"dry"
+			],
+			"concerns": [
+				"dryness"
+			]
+		}
+	],
+	"loved_by_user": [],
+	"disliked_by_user": []
+}
 
-    const productToCheck = sampleProduct;
+const testComputeScore = async () => {
+	const userInfo = user2;
+    const productToCheck = product2;
     const lovedProducts = userInfo.loved_products;
     const dislikedProducts = userInfo.disliked_products;
     const userSkinType = userInfo.skin_type;

--- a/backend/routes/test.js
+++ b/backend/routes/test.js
@@ -1652,9 +1652,29 @@ const product2 = {
 	"disliked_by_user": []
 }
 
+const product3 = { // no ingredients
+	"id": 8,
+	"brand": "Drunk Elephant",
+	"name": "Protini Polypeptide Cream",
+	"image": "https://www.sephora.com/productimages/sku/s2385748-main-zoom.jpg?imwidth=270&pb=clean-at-sephora",
+	"product_type": "moisturizer",
+	"price": "68",
+	"concerns": [
+		"fine lines & wrinkles",
+		"dryness"
+	],
+	"skin_type": [
+		"combination",
+		"normal"
+	],
+	"ingredients": [],
+	"loved_by_user": [],
+	"disliked_by_user": []
+}
+
 const testComputeScore = async () => {
-	const userInfo = user2;
-    const productToCheck = product2;
+	const userInfo = user3;
+    const productToCheck = product3;
     const lovedProducts = userInfo.loved_products;
     const dislikedProducts = userInfo.disliked_products;
     const userSkinType = userInfo.skin_type;


### PR DESCRIPTION
## Description

- added checks for heavily liked/disliked products -- will increase/decrease score for repetitive brands or ingredients within liked/disliked products
- updated weights for products with no ingredients

## Milestones
- TC 1

## Resources
- asked metamate for ideas on edge cases, generally unhelpful

## Test Plan
- added a few more test cases in test.js and compared scores before and after making changes to the algorithm
- for example, got score for product with no ingredients for 3 different users; then tweaked the algorithm so that products with no ingredients have different weights; verified that score went up for all 3 users
- followed similar procedure with the updated liked/disliked system
- also individually tested helper methods (parseDislikedProducts and parseLikedProducts) to verify that they return the right brands and ingredients who had high frequencies.
